### PR TITLE
Import README.rst directly rather than through symlink so easyinstall doesn't fail

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.rst

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(name='PopIt-Python',
     version='0.1.10',
     description='Python bindings to connect to the PopIt API',
-        long_description=open('README', 'rt').read(),
+        long_description=open('README.rst', 'rt').read(),
     author='mySociety',
     author_email='modules@mysociety.org',
     url='https://github.com/mysociety/popit-python',


### PR DESCRIPTION
Fixes #12 
