### PR TITLE
Update required version of python-requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 argparse==1.2.1
-requests==2.2.1
+requests==2.6.0
 slumber==0.6.0
 wsgiref==0.1.2
 Oktest==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(name='PopIt-Python',
     author_email='modules@mysociety.org',
     url='https://github.com/mysociety/popit-python',
     py_modules=['popit_api'],
-    install_requires=['requests==0.14.2','slumber']
+    install_requires=['requests==2.6.0','slumber']
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='PopIt-Python',
-    version='0.1.10',
+    version='0.1.11',
     description='Python bindings to connect to the PopIt API',
         long_description=open('README.rst', 'rt').read(),
     author='mySociety',

--- a/test.py
+++ b/test.py
@@ -81,6 +81,8 @@ class AuthenticationTest(object):
     @classmethod
     def before_all(cls):
         wrong_conf = conf.copy()
+        wrong_conf.pop('api_key', None)
+        wrong_conf['user'] = 'test@test.co.uk'
         wrong_conf['password'] = '3h45hk345h'
         cls.p = PopIt(**wrong_conf)
 


### PR DESCRIPTION
popit-python was using an old version of requests (2.2.1); in addition
we should upgrade it because of the security alert CVE-2015-2296,
which presumably could affect someone who is connecting to a
maliciously configured service.
